### PR TITLE
!fix: added useInnerText option to createStdout

### DIFF
--- a/src/hosted/App.vue
+++ b/src/hosted/App.vue
@@ -64,11 +64,15 @@ export default {
         &nbsp;pokedex pokemon --color<br>
         &nbsp;pwd<br>
         &nbsp;reverse text<br>
+        &nbsp;text-format<br>
       `),
 
       // Return simple text
       'hello-world': () => createStdout('Hello world'),
 
+      // Text format with innerText instead of innerHtml so newline / carriage return can be used
+      'text-format': () => createStdout('Example using createStdout with useInnerText=true: \n allows for formating of message with newline instead of Html <br> (for example)', true),
+      
       // Show a animation
       klieh: () => KliehParty,
 

--- a/src/library.js
+++ b/src/library.js
@@ -2,7 +2,7 @@ import VueCommand from './components/VueCommand'
 import { ARROW_UP_KEY, ARROW_DOWN_KEY, R_KEY, TAB_KEY } from '../src/constants/keys'
 
 // Returns a Stdout component containing a span element with given inner content
-export const createStdout = (content, isEscapeHtml = false, name = 'VueCommandStdout', ...mixins) => ({
+export const createStdout = (content, useInnerText = false, isEscapeHtml = false, name = 'VueCommandStdout', ...mixins) => ({
   name,
   mixins,
   inject: ['terminate'],
@@ -16,6 +16,9 @@ export const createStdout = (content, isEscapeHtml = false, name = 'VueCommandSt
   render: createElement => {
     if (isEscapeHtml) {
       return createElement('span', {}, content)
+    }
+    if (useInnerText) {
+      return createElement('span', { domProps: { innerText: content } })
     }
 
     return createElement('span', { domProps: { innerHTML: content } })


### PR DESCRIPTION
createStdout now have the 'useInnerText' option allowing for content to be formatted with innerText instead of innerHtml. This allows for formatting with newline '\n' (innerText) or instead of '< br >' (innerHtml).

Example command using 'useInnerText=true'
- just add true to second argument of createStdout and \n will be interpreted as newline (other ascii control characters can be used as well, I think)
```js
      'text-format': () => createStdout('Example using createStdout with useInnerText=true: \n allows for formatting of message with newline instead of Html <br> (for example)', true),

```