### PR TITLE
feat!: createStdout now includes option to hide next prompt

### DIFF
--- a/src/components/VueCommand.vue
+++ b/src/components/VueCommand.vue
@@ -36,7 +36,6 @@
         <div v-if="showIntro">
           {{ intro }}
         </div>
-
         <div
           v-for="(stdout, index) in local.history"
           :key="index"
@@ -48,7 +47,7 @@
             class="term-stdout"/>
 
           <stdin
-            v-show="(index === 0 && !local.isFullscreen) || !(index === local.history.length - 1 && local.isInProgress) && !local.isFullscreen"
+            v-show="stdout.includePromptAfter && ((index === 0 && !local.isFullscreen) || !(index === local.history.length - 1 && local.isInProgress) && !local.isFullscreen)"
             ref="stdin"
             :bus="bus"
             :cursor="local.cursor"
@@ -325,6 +324,7 @@ export default {
       // Push dummy Stdout without termination
       history.push({
         name: 'VueCommandDummyStdout',
+        includePromptAfter: true,
         render: createElement => createElement('span', {}, '')
       })
 

--- a/src/hosted/App.vue
+++ b/src/hosted/App.vue
@@ -64,10 +64,23 @@ export default {
         &nbsp;pokedex pokemon --color<br>
         &nbsp;pwd<br>
         &nbsp;reverse text<br>
+        &nbsp;text-format<br>
+        &nbsp;text-format<br>
+        &nbsp;output-no-prompt<br>
+        &nbsp;output-with-prompt<br>
       `),
 
       // Return simple text
       'hello-world': () => createStdout('Hello world'),
+
+      // Text format with innerText instead of innerHtml so newline and other ascii control characters can be used
+      'text-format': () => createStdout('Example using createStdout with useInnerText=true: \n allows for formatting of message with newline instead of Html <br> (including other ascii control characters)', true),
+
+      // stdoutput but do not display prompt after
+      'output-no-prompt': () => createStdout('Example using createStdout with no prompt after \n reload browser to undo', true, false),
+
+      // stdoutput and display prompt after
+      'output-with-prompt': () => createStdout('Example using createStdout with prompt after', true, true),
 
       // Show a animation
       klieh: () => KliehParty,

--- a/src/library.js
+++ b/src/library.js
@@ -2,7 +2,7 @@ import VueCommand from './components/VueCommand'
 import { ARROW_UP_KEY, ARROW_DOWN_KEY, R_KEY, TAB_KEY } from '../src/constants/keys'
 
 // Returns a Stdout component containing a span element with given inner content
-export const createStdout = (content, isInnerText = false, isEscapeHtml = false, name = 'VueCommandStdout', ...mixins) => ({
+export const createStdout = (content, isInnerText = false, includePromptAfter = true, isEscapeHtml = false, name = 'VueCommandStdout', ...mixins) => ({
   name,
   mixins,
   inject: ['terminate'],
@@ -12,12 +12,11 @@ export const createStdout = (content, isInnerText = false, isEscapeHtml = false,
 
     this.terminate()
   },
-
+  includePromptAfter: includePromptAfter,
   render: createElement => {
     if (isEscapeHtml) {
       return createElement('span', {}, content)
     }
-
     if (isInnerText) {
       return createElement('span', { domProps: { innerText: content } })
     }
@@ -37,7 +36,7 @@ export const createStderr = (content, isEscapeHtml = false, name = 'VueCommandSt
 
     this.terminate()
   },
-
+  includePromptAfter: true,
   render: createElement => {
     if (isEscapeHtml) {
       return createElement('span', {}, content)
@@ -49,6 +48,7 @@ export const createStderr = (content, isEscapeHtml = false, name = 'VueCommandSt
 
 // Returns a dummy Stdout component to not show a Stdin
 export const createDummyStdout = (name = 'VueCommandDummyStdout', ...mixins) => ({
+  includePromptAfter: true,
   name,
   mixins,
   inject: ['terminate'],
@@ -58,7 +58,6 @@ export const createDummyStdout = (name = 'VueCommandDummyStdout', ...mixins) => 
 
     this.terminate()
   },
-
   render: createElement => createElement('span', {}, '')
 })
 


### PR DESCRIPTION
New feature allowing VueCommand to render stdout without rendering a stdin (prompt) right after.
- in VueCommand.vue line 50
   + stdin checks stdout.includePromptAfter to determine weather to display prompt or not
- user just needs to do:
   + history.push(createStdout(message, true, false)) or history.push(createStdout(message, false, false)) 
   + the last argument sets the includePromptAfter attribute in the stdout component
- user can add prompt back in by setting next stdout includePromptAfter to true
