### PR TITLE
add options per commands

### DIFF
--- a/src/mixins/handle.js
+++ b/src/mixins/handle.js
@@ -89,7 +89,7 @@ export default {
       let component = createDummyStdout()
 
       const accommodatedTokens = accommodateTokens(stdin)
-      const parsed = getOpts(accommodatedTokens, this.parserOptions)
+      const parsed = getOpts(accommodatedTokens.slice(1), this.parserOptions[program])
 
       component = await Promise.resolve(this.commands[program](parsed))
       component = this.setupComponent(component, this.local.history.length, parsed)

--- a/src/mixins/handle.js
+++ b/src/mixins/handle.js
@@ -89,7 +89,7 @@ export default {
       let component = createDummyStdout()
 
       const accommodatedTokens = accommodateTokens(stdin)
-      const parsed = getOpts(accommodatedTokens.slice(1), this.parserOptions[program])
+      const parsed = getOpts(accommodatedTokens, this.parserOptions[program])
 
       component = await Promise.resolve(this.commands[program](parsed))
       component = this.setupComponent(component, this.local.history.length, parsed)


### PR DESCRIPTION
I did some tests and it should work this way. parser-options should be of the form:
`{
cd:{options},
ls:{options}
}`