### PR TITLE
fixed text selection bug

### DIFF
--- a/src/components/VueCommand.vue
+++ b/src/components/VueCommand.vue
@@ -350,6 +350,9 @@ export default {
 
     // Focus on last Stdin or search
     focus () {
+      // If user selected any text skip setting focus as otherwise the selection gets removed
+      if (window.getSelection().toString() !== '') return
+
       // Check if search mode
       if (this.isSearch) {
         this.$refs.search.focus()


### PR DESCRIPTION
Fixed a text selection bug where a user could not select text in the terminal.
This is really annoying as someone may like to copy the text a command returns to paste it somewhere else.

The solution is quite simple, It just checks now If the user selected anything
If it's not empty, setting the focus is skipped.

Tests still pass.